### PR TITLE
Fixed 'expected models/user.rb to define User' error

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -4,6 +4,9 @@ require 'redmine'
 require 'dispatcher'
 require 'status_user_patch'
 
+require_dependency 'principal'
+require_dependency 'user'
+
 Dispatcher.to_prepare do
   User.send(:include, ::Plugin::Status::User)
   ActiveRecord::Base.observers << :status_observer


### PR DESCRIPTION
Kept getting the above error message when trying to run `rake db:migrate_plugins`. This fixes issue #4.
