### PR TITLE
Routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,14 @@
+ActionController::Routing::Routes.draw do |map|
+
+  map.resources :statuses, :collection => {
+    :search => [ :get, :post ],
+    :tagged => :get,
+    :tag_cloud => :get,
+    :find_project => :get,
+    :project => :get,
+    :find_tag => :get
+  }
+  map.connect 'status_notifications/edit', :controller => :status_notifications, :action => :edit
+  map.connect 'status_notifications/update', :controller => :status_notifications, :action => :update
+
+end

--- a/init.rb
+++ b/init.rb
@@ -4,6 +4,9 @@ require 'redmine'
 require 'dispatcher'
 require 'status_user_patch'
 
+require_dependency 'principal'
+require_dependency 'user'
+
 Dispatcher.to_prepare do
   User.send(:include, ::Plugin::Status::User)
   ActiveRecord::Base.observers << :status_observer


### PR DESCRIPTION
The latest redmine doesn't provide the catch-all :controller/:action routes, so they must all be explicitly named in the plugin. This fixed the No Route Exists errors for me.

This is built off pull #9, so pull that in first and ignore the first commit here.
