### PR TITLE
Fixed issues with status not creating and statuses page not rendering

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -22,7 +22,7 @@ class StatusesController < ApplicationController
   # TODO: Accept XML data.
   
   def create
-    @status = Status.new(params[:status])
+    @status = Status.new(params[:status].reject{ |k,v| k == :project_id })
     @status.user_id = User.current.id
     @status.project_id = check_project_id(@status)
     @status.save

--- a/app/helpers/statuses_helper.rb
+++ b/app/helpers/statuses_helper.rb
@@ -24,7 +24,7 @@ module StatusesHelper
     return '' if @project # on project, no linking needed
     returning '' do |values|
       if status.project
-        values << link_to(h(status.project.name), {:controller => 'statuses', :action => 'index', :id => status.project}, :class => 'smaller_project')
+        values << link_to(h(status.project.name), {:controller => 'statuses', :action => 'index', :id => status.project.identifier}, :class => 'smaller_project')
       end
     end
   end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -5,7 +5,7 @@ class Status < ActiveRecord::Base
   validates_presence_of :project_id
   extend StatusesHelper
   
-  attr_protected :project_id
+  #attr_protected :project_id
   
   Hashtag = /(#\S+)/
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,14 @@
+ActionController::Routing::Routes.draw do |map|
+
+  map.resources :statuses, :collection => {
+    :search => [ :get, :post ],
+    :tagged => :get,
+    :tag_cloud => :get,
+    :find_project => :get,
+    :project => :get,
+    :find_tag => :get
+  }
+  map.connect 'status_notifications/edit', :controller => :status_notifications, :action => :edit
+  map.connect 'status_notifications/update', :controller => :status_notifications, :action => :update
+
+end

--- a/init.rb
+++ b/init.rb
@@ -4,6 +4,9 @@ require 'redmine'
 require 'dispatcher'
 require 'status_user_patch'
 
+require_dependency 'principal'
+require_dependency 'user'
+
 Dispatcher.to_prepare do
   User.send(:include, ::Plugin::Status::User)
   ActiveRecord::Base.observers << :status_observer


### PR DESCRIPTION
This fixes #3 (and probably #1). Once I had fixed that error, I actually encountered another where the /statuses/index page wouldn't render due to the latest redmine using project.identifier to identify the project URLs. This fixes that too (see the helper change).

This is built off pulls #9 and #10, so ignore the first 2 commits.
